### PR TITLE
tccgen: clarify the Nested Functions tcc error

### DIFF
--- a/tccgen.c
+++ b/tccgen.c
@@ -8854,7 +8854,7 @@ static int decl0(int l, int is_for_loop_init, Sym *func_sym)
 #endif
             if (tok == '{') {
                 if (l != VT_CONST)
-                    tcc_error("cannot use local functions");
+                    tcc_error("Nested definition of functions(){} is not supported by C programming language.");
                 if ((type.t & VT_BTYPE) != VT_FUNC)
                     expect("function definition");
 


### PR DESCRIPTION
The error that detects the nested function is unclear and less informative than expected.

The example to trigger this error:
Filename: `nested-functions-error-test.c`

```
main(){
	
	int functionthathasname(){
		
		
		
	}
	
	
	
}
```

Command line: 
```
C:\Users\user\Desktop\latest-built>tcc -run nested-functions-error-test.c
nested-functions-error-test.c:3: error: cannot use local functions
```

![image](https://user-images.githubusercontent.com/21064622/120754809-d4cb2400-c515-11eb-89b9-7989345b9e24.png)
I was confused by this error for some time, I decided to change that.

To this:
![image](https://user-images.githubusercontent.com/21064622/120754510-743be700-c515-11eb-9ddc-d24405ab510e.png)
