### PR TITLE
Remove unused assignments in x86_64-gen.c, i386-asm.c, and tccpp.c

### DIFF
--- a/i386-asm.c
+++ b/i386-asm.c
@@ -1349,7 +1349,6 @@ ST_FUNC void asm_compute_constraints(ASMOperand *operands,
 	if (op->reg >= 0) {
 	    if (is_reg_allocated(op->reg))
 	        tcc_error("asm regvar requests register that's taken already");
-	    reg = op->reg;
 	}
     try_next:
         c = *str++;
@@ -1536,10 +1535,11 @@ ST_FUNC void subst_asm_operand(CString *add_str,
                 goto no_offset;
 	    cstr_ccat(add_str, '+');
         }
-        val = sv->c.i;
+        val = (int)sv->c.i;
         if (modifier == 'n')
-            val = -val;
-        cstr_printf(add_str, "%d", (int)sv->c.i);
+            cstr_printf(add_str, "%d", -val);
+	else
+            cstr_printf(add_str, "%d", val);
     no_offset:;
 #ifdef TCC_TARGET_X86_64
         if (r & VT_LVAL)

--- a/tccpp.c
+++ b/tccpp.c
@@ -1461,7 +1461,6 @@ static int expr_preprocess(TCCState *s1)
     pp_expr = 1;
     while (1) {
         next(); /* do macro subst */
-        t = tok;
         if (tok < TOK_IDENT) {
             if (tok == TOK_LINEFEED || tok == TOK_EOF)
                 break;

--- a/x86_64-gen.c
+++ b/x86_64-gen.c
@@ -1800,7 +1800,6 @@ void gen_opi(int op)
         /* first operand must be in eax */
         /* XXX: need better constraint for second operand */
         gv2(RC_RAX, RC_RCX);
-        r = vtop[-1].r;
         fr = vtop[0].r;
         vtop--;
         save_reg(TREG_RDX);
@@ -1925,8 +1924,6 @@ void gen_opf(int op)
                     a++;
                 break;
             }
-            ft = vtop->type.t;
-            fc = vtop->c.i;
             o(0xde); /* fxxxp %st, %st(1) */
             o(0xc1 + (a << 3));
             vtop--;


### PR DESCRIPTION
### Describe

Hi :)

While reviewing the code in x86_64-gen.c and other parts of the codebase, I found several dead store assignments where values are written to variables that are never used. These lines were likely copied or refactored from similar code blocks, but the variables end up unused, which can confuse readers and make maintenance harder.

### Expected behavior

Any variable assignment in the code should serve a purpose.

If a value is no longer needed, the assignment should be removed.

### Actual behavior

There are several assignments to variables that never get used afterward, causing unnecessary noise in the code:

- In `x86_64-gen.c`, the variable `r` is assigned but then re-assigned shortly after, rendering the initial assignment useless.
- Also in `x86_64-gen.c`, the variables `ft` and `fc` are assigned but never used before the function returns.
- In `i386-asm.c`, the value `reg = op->reg` is overwritten before being used.
- In `subst_asm_operand()`, `val = -val` is computed but ignored, so the `'n'` modifier has no effect.
- In `tccpp.c`, `t = tok` is assigned at the start of a loop but is immediately overwritten in the next iteration.

These patterns introduce misleading or redundant operations and, in some cases, lead to functional omissions.

### How to Reproduce

Review the following code snippets:

### `x86_64-gen.c`

```c
1803 r = vtop[-1].r;      // ← never used before reassignment
1928 ft = vtop->type.t;   // ← never used
1929 fc = vtop->c.i;      // ← never used
```

### `i386-asm.c`

```c
1352 reg = op->reg;       // ← never used before being overwritten
1541 val = -val;          // ← computed but never used
```

### `tccpp.c`

```c
1464 t = tok;             // ← overwritten later without use
```

### Anything Else?

These adjustments are small but meaningful improvements to the codebase.

They remove misleading logic, restore intended behavior, and improve overall maintainability.

Thank you for reviewing.

---
Co-authored-by: NaHyeon Kim <jhnh204@gmail.com>