### PR TITLE
Fix shadowed parameter in greloca()

### DIFF
--- a/tccgen.c
+++ b/tccgen.c
@@ -604,10 +604,12 @@ ST_FUNC void greloca(Section *s, Sym *sym, unsigned long offset, int type,
                 && (sym->type.t & (VT_STATIC|VT_EXTERN)) == (VT_STATIC|VT_EXTERN)) {
                 /* when a local function declaraion redeclares a global static one
                    then tccelf would not resolve them to the same symbol. */
-                Sym *s = sym;
-                while (s->prev_tok)
-                    s = s->prev_tok;
-                s->c = sym->c;
+
+                    Sym *sym_it = sym;
+                    while (sym_it->prev_tok)
+                        sym_it = sym_it->prev_tok;
+                    sym_it->c = sym->c;
+                
             }
         }
         c = sym->c;

--- a/tcctools.c
+++ b/tcctools.c
@@ -81,7 +81,7 @@ ST_FUNC int tcc_tool_ar(int argc, char **argv)
     int *afpos = NULL;
     int istrlen, strpos = 0, fpos = 0, funccnt = 0, funcmax, hofs;
     char tfile[260], stmp[20];
-    char *file, *name;
+    char *ar_file, *name;
     int ret = 2;
     const char *ops_conflict = "habdiopN";  // unsupported but destructive if ignored.
     int extract = 0;
@@ -272,9 +272,9 @@ finish:
             }
         }
 
-        file = argv[i_obj];
-        for (name = strchr(file, 0);
-             name > file && name[-1] != '/' && name[-1] != '\\';
+        ar_file = argv[i_obj];
+        for (name = strchr(ar_file, 0);
+             name > ar_file && name[-1] != '/' && name[-1] != '\\';
              --name);
         istrlen = strlen(name);
         if (istrlen >= sizeof(arhdro.ar_name))


### PR DESCRIPTION
This PR resolves a -Wshadow warning in tccgen.c.

Inside greloca(), the function parameter `Section *s` was shadowed by a
local variable also named `s`:

    Sym *s = sym;

Shadowing parameters inside core relocation logic makes it harder to
reason about symbol resolution and maintain the code safely.

The local variable has been renamed to `sym_it` to avoid the shadowing.
No functional or semantic changes were introduced.

Build passes cleanly with -Wall -Wunused -Wshadow.
