### PR TITLE
Fix shadowed variable in macro_arg_subst() in preprocessor

### DIFF
--- a/tccgen.c
+++ b/tccgen.c
@@ -604,10 +604,12 @@ ST_FUNC void greloca(Section *s, Sym *sym, unsigned long offset, int type,
                 && (sym->type.t & (VT_STATIC|VT_EXTERN)) == (VT_STATIC|VT_EXTERN)) {
                 /* when a local function declaraion redeclares a global static one
                    then tccelf would not resolve them to the same symbol. */
-                Sym *s = sym;
-                while (s->prev_tok)
-                    s = s->prev_tok;
-                s->c = sym->c;
+
+                    Sym *sym_it = sym;
+                    while (sym_it->prev_tok)
+                        sym_it = sym_it->prev_tok;
+                    sym_it->c = sym->c;
+                
             }
         }
         c = sym->c;

--- a/tccpp.c
+++ b/tccpp.c
@@ -3024,7 +3024,7 @@ static int macro_subst(
     Sym **nested_list,
     const int *macro_str
     );
-
+    
 /* substitute arguments in replacement lists in macro_str by the values in
    args (field d) and return allocated string */
 static int *macro_arg_subst(Sym **nested_list, const int *macro_str, Sym *args)
@@ -3059,17 +3059,18 @@ static int *macro_arg_subst(Sym **nested_list, const int *macro_str, Sym *args)
                 cstr_ccat(&tokcstr, '\"');
                 st = s->d;
                 while (*st != TOK_EOF) {
-                    const char *s;
+                    const char *tok_ptr;
                     TOK_GET(&t, &st, &cval);
-                    s = get_tok_str(t, &cval);
-                    while (*s) {
-                        if (t == TOK_PPSTR && *s != '\'')
-                            add_char(&tokcstr, *s);
+                    tok_ptr = get_tok_str(t, &cval);
+                    while (*tok_ptr) {
+                        if (t == TOK_PPSTR && *tok_ptr != '\'')
+                            add_char(&tokcstr, *tok_ptr);
                         else
-                            cstr_ccat(&tokcstr, *s);
-                        ++s;
+                            cstr_ccat(&tokcstr, *tok_ptr);
+                        ++tok_ptr;
                     }
                 }
+
                 cstr_ccat(&tokcstr, '\"');
                 cstr_ccat(&tokcstr, '\0');
                 //printf("\nstringize: <%s>\n", (char *)tokcstr.data);

--- a/tcctools.c
+++ b/tcctools.c
@@ -81,7 +81,7 @@ ST_FUNC int tcc_tool_ar(int argc, char **argv)
     int *afpos = NULL;
     int istrlen, strpos = 0, fpos = 0, funccnt = 0, funcmax, hofs;
     char tfile[260], stmp[20];
-    char *file, *name;
+    char *ar_file, *name;
     int ret = 2;
     const char *ops_conflict = "habdiopN";  // unsupported but destructive if ignored.
     int extract = 0;
@@ -272,9 +272,9 @@ finish:
             }
         }
 
-        file = argv[i_obj];
-        for (name = strchr(file, 0);
-             name > file && name[-1] != '/' && name[-1] != '\\';
+        ar_file = argv[i_obj];
+        for (name = strchr(ar_file, 0);
+             name > ar_file && name[-1] != '/' && name[-1] != '\\';
              --name);
         istrlen = strlen(name);
         if (istrlen >= sizeof(arhdro.ar_name))


### PR DESCRIPTION
This PR fixes a -Wshadow warning inside macro_arg_subst() in tccpp.c.

The macro argument substitution logic declared an inner `const char *s` 
which shadowed the outer `Sym *s` used for macro argument symbols. Since 
macro_arg_subst() handles token copying, nested expansion, and CPP 
stringization rules, this shadow made the code harder to reason about and 
increased the risk of subtle macro expansion bugs.

The inner variable has been renamed to `tok_ptr`, removing the shadowing 
without changing functionality or semantics.

Build passes successfully with:
    -Wall -Wunused -Wshadow
