### PR TITLE
pp_line: do not swallow #line with negative deltas

### DIFF
--- a/tccpp.c
+++ b/tccpp.c
@@ -3802,7 +3802,11 @@ static void pp_line(TCCState *s1, BufferedFile *f, int level)
 
     if (s1->Pflag == LINE_MACRO_OUTPUT_FORMAT_NONE) {
         ;
-    } else if (level == 0 && f->line_ref && d < 8) {
+    } else if (level == 0 && f->line_ref && d >= 0 && d < 8) {
+	/* Negative d (e.g. #line resume after a large synthetic injection)
+	 * must not take the short-newline swallow path: while (d > 0) is a
+	 * no-op then, so the directive was silently dropped and line
+	 * tracking drifted. Restrict the swallow to non-negative deltas. */
 	while (d > 0)
 	    fputs("\n", s1->ppfp), --d;
     } else if (s1->Pflag == LINE_MACRO_OUTPUT_FORMAT_STD) {


### PR DESCRIPTION
## Summary
- `pp_line` takes the short-newline swallow path when `level == 0 && f->line_ref && d < 8`.
- Negative `d` (a `#line` that resumes an earlier line after a large synthetic injection) still matches `d < 8`, but `while (d > 0)` is a no-op, so the directive is silently dropped and line tracking drifts.
- Restrict the swallow to `d >= 0 && d < 8` so negative deltas fall through to the normal `#line` / `# N` emission.

## Context
Hit this while preserving user-source line numbers after prepending generated declarations (Concurrent-C). Reproducible with any preprocess (`-E` / `LINE_MACRO_OUTPUT`) flow that emits `#line N` with `N` smaller than the current physical line by 8+.

## Test plan
- [ ] `tcc -E` a file that does a large injection then `#line` back to a small line number; confirm the `#line` (or `# N`) appears in the output
- [ ] Existing preprocess / diagnostic tests still pass

Made with [Cursor](https://cursor.com)