### PR TITLE
dwarf: use unsigned loop index in LEB128 readers

### DIFF
--- a/tcc.h
+++ b/tcc.h
@@ -1876,7 +1876,7 @@ dwarf_read_uleb128(unsigned char **ln, unsigned char *end)
 {
     unsigned char *cp = *ln;
     uint64_t retval = 0;
-    int i;
+    unsigned i;
     for (i = 0; i < DWARF_MAX_128; i++) {
 	uint64_t byte = dwarf_read_1(cp, end);
         retval |= (byte & 0x7f) << (i * 7);
@@ -1891,7 +1891,7 @@ dwarf_read_sleb128(unsigned char **ln, unsigned char *end)
 {
     unsigned char *cp = *ln;
     int64_t retval = 0;
-    int i;
+    unsigned i;
     for (i = 0; i < DWARF_MAX_128; i++) {
 	uint64_t byte = dwarf_read_1(cp, end);
         retval |= (byte & 0x7f) << (i * 7);


### PR DESCRIPTION
## Summary
- In `dwarf_read_uleb128` / `dwarf_read_sleb128`, the loop index `i` is compared against `DWARF_MAX_128` and used only as a shift count.
- Change `int i` to `unsigned i` to quiet `-Wsign-compare` under stricter warning builds.

## Test plan
- [ ] Build with `-Wsign-compare` (or the project default warning set) and confirm the two LEB128 readers no longer warn
- [ ] Existing DWARF / debug-info tests still pass

Made with [Cursor](https://cursor.com)